### PR TITLE
Add configurable auto insert and chat history limit

### DIFF
--- a/asa-ai-sales-agent/js/asa-script.js
+++ b/asa-ai-sales-agent/js/asa-script.js
@@ -15,13 +15,14 @@
         const clearHistoryBtn = chatbot.find('.asa-clear-history');
         
         let history = [];
+        const historyLimit = parseInt(asaSettings.historyLimit, 10) || 50;
         let proactiveMessageTimeout;
 
         // Geçmişi yükle ve render et
         try {
             const storedHistory = JSON.parse(localStorage.getItem('asa_chat_history'));
             if (Array.isArray(storedHistory)) {
-                history = storedHistory;
+                history = storedHistory.slice(-historyLimit);
                 history.forEach(msg => {
                     renderMessage(msg.role, msg.parts[0].text); // Sadece render et, geçmişe tekrar ekleme
                 });
@@ -187,6 +188,9 @@
         // İyileştirme: Hem geçmişi güncelleyen hem de render eden fonksiyon
         function updateHistoryAndRender(sender, text) {
             history.push({ role: sender, parts: [{ text: text }] });
+            if (history.length > historyLimit) {
+                history = history.slice(-historyLimit);
+            }
             localStorage.setItem('asa_chat_history', JSON.stringify(history));
             renderMessage(sender, text);
         }

--- a/asa-ai-sales-agent/readme.txt
+++ b/asa-ai-sales-agent/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, chatbot, sales, gemini, google
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,7 +26,7 @@ Enhance your customer engagement and boost your sales with an intelligent AI ass
 1.  **Upload the plugin files** to the `/wp-content/plugins/asa-ai-sales-agent` directory, or install the plugin through the WordPress plugins screen directly.
 2.  **Activate the plugin** through the 'Plugins' screen in WordPress.
 3.  **Go to `Settings > ASA AI Sales Agent`** to configure your Gemini API Key and customize the chatbot's appearance and behavior.
-4.  **Add the shortcode `[asa_chatbot]`** to any page or post where you want the chatbot to appear. Alternatively, the chatbot will automatically appear on all pages if the shortcode is not used, as it's hooked into `wp_footer`.
+4.  **Add the shortcode `[asa_chatbot]`** to any page or post where you want the chatbot to appear. The plugin can also insert the bot automatically on selected page types via the settings page.
 
 == Frequently Asked Questions ==
 
@@ -43,6 +43,11 @@ Yes, the ASA AI Sales Agent plugin is 100% free to use. While the plugin itself 
 4. Chatbot on Frontend
 
 == Changelog ==
+
+= 1.0.2 =
+* Added option to disable automatic footer injection and choose page types.
+* Implemented API error logging to `error.log`.
+* Limited stored chat history with configurable limit.
 
 = 1.0.1 =
 * Added DOMPurify sanitization for AI responses.

--- a/asa-ai-sales-agent/uninstall.php
+++ b/asa-ai-sales-agent/uninstall.php
@@ -12,7 +12,10 @@ $option_names = [
     'asa_avatar_icon',
     'asa_avatar_image_url',
     'asa_position',
-    'asa_show_credit'
+    'asa_show_credit',
+    'asa_auto_insert',
+    'asa_display_types',
+    'asa_history_limit'
 ];
 
 foreach ($option_names as $option) {


### PR DESCRIPTION
## Summary
- add settings for automatic footer insertion and page type filters
- log API errors to a new `error.log` file
- limit stored chat history and expose setting
- update uninstall script and docs

## Testing
- `php -l asa-ai-sales-agent/asa-ai-sales-agent.php`
- `node --check asa-ai-sales-agent/js/asa-script.js`
- `php -l asa-ai-sales-agent/uninstall.php`


------
https://chatgpt.com/codex/tasks/task_b_687f560e433c8331a31887820d82f036