### PR TITLE
Implement API key test and error handling improvements

### DIFF
--- a/asa-ai-sales-agent/js/asa-admin.js
+++ b/asa-ai-sales-agent/js/asa-admin.js
@@ -62,6 +62,26 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+    // --- 4. TEST API KEY ---
+    $('#asa-test-api-key').on('click', function(e) {
+        e.preventDefault();
+        const statusEl = $('#asa-api-key-test-status');
+        statusEl.text(asaAdminSettings.testingText).removeClass('success error');
+        $.post(asaAdminSettings.ajaxUrl, {
+            action: 'asa_test_api_key',
+            security: asaAdminSettings.nonce,
+            apiKey: $('#asa_api_key').val()
+        }).done(function(res) {
+            if (res.success) {
+                statusEl.text(asaAdminSettings.testSuccessText).addClass('success');
+            } else {
+                statusEl.text(asaAdminSettings.testErrorText).addClass('error');
+            }
+        }).fail(function(jqXHR) {
+            statusEl.text(asaAdminSettings.ajaxErrorText + jqXHR.statusText).addClass('error');
+        });
+    });
     
     
 

--- a/asa-ai-sales-agent/readme.txt
+++ b/asa-ai-sales-agent/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, chatbot, sales, gemini, google
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -43,6 +43,10 @@ Yes, the ASA AI Sales Agent plugin is 100% free to use. While the plugin itself 
 4. Chatbot on Frontend
 
 == Changelog ==
+
+= 1.0.3 =
+* Added API key testing functionality in settings.
+* Improved API error handling for non-200 responses.
 
 = 1.0.2 =
 * Added option to disable automatic footer injection and choose page types.


### PR DESCRIPTION
## Summary
- add AJAX action for API key testing and admin button
- handle non-200 API responses
- drop unused property and closing PHP tag
- bump plugin version to 1.0.3
- document new feature in changelog

## Testing
- `php -l asa-ai-sales-agent/asa-ai-sales-agent.php`


------
https://chatgpt.com/codex/tasks/task_b_687f5849252c8331ab98616457e8c67b