### PR TITLE
Improve proactive message options and responsiveness

### DIFF
--- a/asa-ai-sales-agent/asa-ai-sales-agent.php
+++ b/asa-ai-sales-agent/asa-ai-sales-agent.php
@@ -3,7 +3,7 @@
 Plugin Name: ASA AI Sales Agent
 Description: AI Sales Agent chatbot powered by Google Gemini API.
 
-Version: 1.0.4
+Version: 1.0.5
 Author: Adem Isler
 Author URI: https://ademisler.com
 Text Domain: asa-ai-sales-agent
@@ -13,7 +13,7 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */
 
-define('ASA_VERSION', '1.0.4');
+define('ASA_VERSION', '1.0.5');
 
 if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
@@ -75,6 +75,7 @@ class ASAAISalesAgent {
             'showCredit' => get_option('asa_show_credit', 'yes'),
             'hasApiKey' => ! empty(get_option('asa_api_key')),
             'proactiveMessage' => $this->generate_proactive_message(),
+            'proactiveDelay'  => intval(get_option('asa_proactive_delay', 3000)),
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('asa_chat_nonce'),
             'currentPageUrl' => get_permalink(),
@@ -140,6 +141,7 @@ class ASAAISalesAgent {
             'asa_show_credit'       => 'sanitize_text_field',
             'asa_auto_insert'      => 'sanitize_text_field',
             'asa_history_limit'    => 'absint',
+            'asa_proactive_delay'  => 'absint',
             'asa_display_types'    => [ $this, 'sanitize_display_types' ]
         ];
 
@@ -166,6 +168,7 @@ class ASAAISalesAgent {
         update_option('asa_show_credit', sanitize_text_field(wp_unslash($_POST['asa_show_credit'] ?? '')));
         update_option('asa_auto_insert', sanitize_text_field(wp_unslash($_POST['asa_auto_insert'] ?? 'no')));
         update_option('asa_history_limit', absint(wp_unslash($_POST['asa_history_limit'] ?? 50)));
+        update_option('asa_proactive_delay', absint(wp_unslash($_POST['asa_proactive_delay'] ?? 3000)));
         $display_types = isset($_POST['asa_display_types']) ? (array) wp_unslash($_POST['asa_display_types']) : [];
         update_option('asa_display_types', $this->sanitize_display_types($display_types));
 
@@ -366,6 +369,13 @@ class ASAAISalesAgent {
                             <label class="asa-section-label"><?php esc_html_e('History Limit', 'asa-ai-sales-agent'); ?></label>
                             <div class="asa-section-content">
                                 <input type="number" name="asa_history_limit" min="1" value="<?php echo esc_attr(get_option('asa_history_limit', 50)); ?>" />
+                            </div>
+                        </div>
+                        <div class="asa-card-section">
+                            <label class="asa-section-label"><?php esc_html_e('Proactive Delay (ms)', 'asa-ai-sales-agent'); ?></label>
+                            <div class="asa-section-content">
+                                <input type="number" name="asa_proactive_delay" min="0" value="<?php echo esc_attr(get_option('asa_proactive_delay', 3000)); ?>" />
+                                <p class="description"><?php esc_html_e('Delay before the proactive message appears.', 'asa-ai-sales-agent'); ?></p>
                             </div>
                         </div>
                     </div>
@@ -674,6 +684,7 @@ function asa_activate_plugin() {
     add_option('asa_auto_insert', 'yes');
     add_option('asa_display_types', ['everywhere']);
     add_option('asa_history_limit', 50);
+    add_option('asa_proactive_delay', 3000);
 }
 register_activation_hook(__FILE__, 'asa_activate_plugin');
 

--- a/asa-ai-sales-agent/css/asa-admin.css
+++ b/asa-ai-sales-agent/css/asa-admin.css
@@ -330,3 +330,17 @@ body { background-color: var(--asa-bg-main); }
     font-weight: 600;
     margin-top: 6px;
 }
+
+@media (max-width: 600px) {
+    .asa-card-section {
+        flex-direction: column;
+    }
+    .asa-section-label {
+        width: 100%;
+        margin-bottom: 10px;
+    }
+    .asa-api-key-input-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/asa-ai-sales-agent/css/asa-style.css
+++ b/asa-ai-sales-agent/css/asa-style.css
@@ -146,8 +146,8 @@
 }
 
 #asa-chatbot .asa-window {
-    width: 370px;
-    height: 500px;
+    width: min(90vw, 370px);
+    height: min(80vh, 500px);
     background: var(--asa-bg-light);
     border-radius: 16px;
     box-shadow: 0 5px 25px rgba(0,0,0,0.08);

--- a/asa-ai-sales-agent/js/asa-script.js
+++ b/asa-ai-sales-agent/js/asa-script.js
@@ -12,6 +12,8 @@
         const clearBtn = chatbot.find('.asa-clear-input');
         const welcomeWrapper = chatbot.find('.asa-welcome-wrapper');
         const proactiveCloseBtn = chatbot.find('.asa-proactive-close');
+        const proactiveClosedKey = 'asa_proactive_closed';
+        const proactiveDelay = parseInt(asaSettings.proactiveDelay, 10) || 3000;
         const clearHistoryBtn = chatbot.find('.asa-clear-history');
 
         let focusableEls = $();
@@ -50,6 +52,9 @@
         }
 
         function fetchProactiveMessage() {
+            if (sessionStorage.getItem(proactiveClosedKey) === 'true') {
+                return;
+            }
             $.ajax({
                 url: asaSettings.proactiveMessageAjaxUrl,
                 type: 'POST',
@@ -63,26 +68,27 @@
                 dataType: 'json',
                 success: function(response) {
                     if (response.success && response.data) {
-                        const delay = Math.floor(Math.random() * 2000) + 2000;
                         setTimeout(() => {
                             welcomeWrapper.find('.asa-proactive-message').text(response.data);
                             welcomeWrapper.addClass('active');
-                            // İyileştirme: 15 saniye sonra gizle
-                            proactiveMessageTimeout = setTimeout(() => welcomeWrapper.removeClass('active'), 15000);
-                        }, delay);
+                            proactiveMessageTimeout = setTimeout(() => hideProactiveMessage(), 15000);
+                        }, proactiveDelay);
                     }
                 }
             });
         }
         
-        function hideProactiveMessage() {
+        function hideProactiveMessage(permanent = false) {
             clearTimeout(proactiveMessageTimeout);
             welcomeWrapper.removeClass('active');
+            if (permanent) {
+                sessionStorage.setItem(proactiveClosedKey, 'true');
+            }
         }
 
         proactiveCloseBtn.on('click', (e) => {
             e.stopPropagation();
-            hideProactiveMessage();
+            hideProactiveMessage(true);
         });
 
         function updateFocusable() {

--- a/asa-ai-sales-agent/readme.txt
+++ b/asa-ai-sales-agent/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, chatbot, sales, gemini, google
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -43,6 +43,11 @@ Yes, the ASA AI Sales Agent plugin is 100% free to use. While the plugin itself 
 4. Chatbot on Frontend
 
 == Changelog ==
+
+= 1.0.5 =
+* Added option to control proactive message delay.
+* Proactive message dismissal now remembered per session.
+* Improved responsive layouts for chat window and admin settings.
 
 = 1.0.4 =
 * Improved accessibility with ARIA roles and keyboard navigation.


### PR DESCRIPTION
## Summary
- make chat window width/height responsive
- allow customizing proactive message delay and remember dismissal
- adjust admin page for mobile layouts
- bump plugin version to 1.0.5

## Testing
- `php -l asa-ai-sales-agent.php`


------
https://chatgpt.com/codex/tasks/task_b_687f6a89e97083319a8c4b0051e73705